### PR TITLE
Fixes for dynamic topic joy publishers

### DIFF
--- a/joy_teleop/setup.py
+++ b/joy_teleop/setup.py
@@ -11,7 +11,7 @@ setup(
         ('share/' + package_name, ['package.xml']),
         ('share/' + package_name + '/config/', ['config/joy_teleop_example.yaml']),
         ('share/' + package_name + '/launch/', ['launch/example.launch.py']),
-        ('share/' + package_name + '/test/', ['test/key_teleop.test.py']),
+        ('share/' + package_name + '/test/', ['test/test_key_teleop.py']),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
- `match_command()` now compares button array length to the `max`
  deadman button index (apples to apples)
- `match_command` function now checks if any of the deadman buttons
  are depressed before returning a match
- properly handle a `std_msgs/msg/Empty` `message_value` by not
  attempting to access its value
- utilizes iter-items to correctly index into the config dict
  for `axis_mappings`'s `axis` and `button` values
- `set_member()` now splits according to a dash (`-`) rather than a
  period (`.`) to be consistent with ros2 param parsing & example yaml
- adds the correct name to `setup.py` for `test_key_teleop.py` test